### PR TITLE
Fixed bug in 16-bit frame length when buffer is a subarray

### DIFF
--- a/lib/websocket/frame.js
+++ b/lib/websocket/frame.js
@@ -43,7 +43,7 @@ class WebsocketFrameSend {
     buffer[1] = payloadLength
 
     if (payloadLength === 126) {
-      new DataView(buffer.buffer).setUint16(2, bodyLength)
+      new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength).setUint16(2, bodyLength)
     } else if (payloadLength === 127) {
       // Clear extended payload length
       buffer[2] = buffer[3] = 0


### PR DESCRIPTION
I was just bitten by this issue.

Because `buffer` could be a [subarray](https://nodejs.org/api/buffer.html#bufsubarraystart-end), the `byteOffset` and `byteLength` arguments to `new DataView()` are required, otherwise the `bodyLength` value may be written at the wrong offset.

Alternatively, it looks like it would be simpler (and I've tested it works fine) to replace the patched line with `buffer.writeUInt16BE(bodyLength, 2)`.